### PR TITLE
(feat) Add develop command

### DIFF
--- a/commands/develop-api.js
+++ b/commands/develop-api.js
@@ -1,3 +1,5 @@
+import { spawn } from "child_process";
+import diehard from "diehard";
 import Logger from "../utils/logger.js";
 
 /**
@@ -7,4 +9,26 @@ import Logger from "../utils/logger.js";
  */
 export default async function developApi(options) {
   Logger.info({ options }, "starting development on api");
+  Logger.info("Starting Mongo docker image");
+  const mongo = spawn("docker-compose", ["up", "-d"]);
+  mongo.stdout.on("data", (data) => {
+    // eslint-disable-next-line no-console
+    console.log(data.toString().trim()); // Echo output of command to console
+  });
+  Logger.info("Starting Open Commerce API Server in dev mode");
+  const api = spawn("npm", ["run", "start:dev"]);
+  api.stdout.on("data", (data) => {
+    // eslint-disable-next-line no-console
+    console.log(data.toString().trim()); // Echo output of command to console
+  });
+
+  diehard.register(async (signal, uncaughtErr, done) => {
+    if (signal === "SIGINT") {
+      Logger.warn("Shutting down from Ctrl-C");
+    }
+    await spawn("docker-compose", ["down"]);
+    done();
+  });
+
+  diehard.listen();
 }

--- a/commands/develop.js
+++ b/commands/develop.js
@@ -1,3 +1,4 @@
+import checkDependencies from "../utils/checkDependencies.js";
 import developStorefront from "./develop-storefront.js";
 import developAdmin from "./develop-admin.js";
 import developApi from "./develop-api.js";
@@ -16,5 +17,8 @@ const functionMap = {
  * @returns {Promise<Boolean>} True for success
  */
 export default async function develop(projectType, options) {
-  await functionMap[projectType](options);
+  if (await checkDependencies()) {
+    return functionMap[projectType](options);
+  }
+  return false;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "command-exists": "^1.2.9",
         "commander": "^8.3.0",
         "concat-stream": "^2.0.0",
+        "diehard": "^1.5.2",
         "fs-extra": "^10.0.0",
         "jest": "^27.3.1",
         "meant": "^2.0.1",
@@ -1534,6 +1535,14 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2143,6 +2152,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -2260,6 +2274,24 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diehard": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/diehard/-/diehard-1.5.2.tgz",
+      "integrity": "sha512-mNTpZsI8lhdbqyI6Oi1YSUz84qh6dADU2W+nEQa+rDJpmnrk6rub7IGfgJH21GEri5XhFRUn/zfFOEnU6e+SWg==",
+      "dependencies": {
+        "async": "^2.5",
+        "death": "^1.1",
+        "debug": "^3.1"
+      }
+    },
+    "node_modules/diehard/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/diff": {
@@ -5139,8 +5171,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.1.25",
@@ -7884,6 +7915,14 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -8355,6 +8394,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -8440,6 +8484,26 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+    },
+    "diehard": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/diehard/-/diehard-1.5.2.tgz",
+      "integrity": "sha512-mNTpZsI8lhdbqyI6Oi1YSUz84qh6dADU2W+nEQa+rDJpmnrk6rub7IGfgJH21GEri5XhFRUn/zfFOEnU6e+SWg==",
+      "requires": {
+        "async": "^2.5",
+        "death": "^1.1",
+        "debug": "^3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "diff": {
       "version": "5.0.0",
@@ -10555,8 +10619,7 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
       "version": "3.1.25",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "command-exists": "^1.2.9",
     "commander": "^8.3.0",
     "concat-stream": "^2.0.0",
+    "diehard": "^1.5.2",
     "fs-extra": "^10.0.0",
     "jest": "^27.3.1",
     "meant": "^2.0.1",


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

This is actually the `develop api` command, but api is the default

To Test:

Clone this repo:

Run:
`./index.js create-project api mydir` (creates project)
`cd mydir`
`npm install` (thinking of adding this to create-project but not sure, for now run manually)
`../index.js develop`

Should start Mongo in the docker container and MOC and show the output of the logging. Ctrl-C will halt both the docker container and MOC.
