### PR TITLE
fix: improved/cleaner logging

### DIFF
--- a/commands/create-plugin.js
+++ b/commands/create-plugin.js
@@ -6,5 +6,5 @@ import Logger from "../utils/logger.js";
  * @returns {Promise<Boolean>} True for success
  */
 export default async function createPlugin(pluginName) {
-  Logger.info({ pluginName }, "Creating plugin");
+  Logger.info("Creating plugin", { pluginName });
 }

--- a/commands/create-project-admin.js
+++ b/commands/create-project-admin.js
@@ -10,7 +10,7 @@ import Logger from "../utils/logger.js";
  * @returns {Boolean} true for success
  */
 export default async function createProjectAdmin(projectName, options) {
-  Logger.info({ projectName, options }, "Creating admin");
+  Logger.info("Creating admin", { projectName, options });
   const gitOptions = {
     baseDir: `${process.cwd()}`,
     binary: "git",
@@ -23,7 +23,7 @@ export default async function createProjectAdmin(projectName, options) {
     Logger.error(error);
   }
   await copy(`${projectName}/.env.example`, `${projectName}/.env`);
-  Logger.info("Admin project created. You can change to this directory and run `npm install`");
+  Logger.success("Admin project created. You can change to this directory and run `npm install`");
   return true;
 }
 

--- a/commands/create-project-api.js
+++ b/commands/create-project-api.js
@@ -118,7 +118,7 @@ async function gitInitDirectory(projectName) {
  * @returns {Boolean} true for success
  */
 export default async function createProjectApi(projectName, options) {
-  Logger.info({ projectName, options }, "Creating API project");
+  Logger.info("Creating API project", { projectName, options });
   if (await pathExists(projectName)) {
     Logger.error(`Cannot create directory ${projectName}, already exists`);
     return;
@@ -135,5 +135,5 @@ export default async function createProjectApi(projectName, options) {
   // git init the new project
   await gitInitDirectory(projectName);
 
-  Logger.info("Project creation complete. Change to your directory and run `npm install`");
+  Logger.success("Project creation complete. Change to your directory and run `npm install`");
 }

--- a/commands/create-project-storefront.js
+++ b/commands/create-project-storefront.js
@@ -10,10 +10,10 @@ import Logger from "../utils/logger.js";
  * @returns {Boolean} true for success
  */
 export default async function createProjectStorefront(projectName, options) {
-  Logger.info({
+  Logger.info("Creating Storefront", {
     projectName,
     options
-  }, "Creating Storefront");
+  });
   const gitOptions = {
     baseDir: `${process.cwd()}`,
     binary: "git",
@@ -26,6 +26,6 @@ export default async function createProjectStorefront(projectName, options) {
     Logger.error(error);
   }
   await copy(`${projectName}/.env.example`, `${projectName}/.env`);
-  Logger.info("Storefront project created. You can change to this directory and run `npm install`");
+  Logger.success("Storefront project created. You can change to this directory and run `npm install`");
   return true;
 }

--- a/commands/develop-admin.js
+++ b/commands/develop-admin.js
@@ -8,7 +8,7 @@ import Logger from "../utils/logger.js";
  * @returns {Boolean} true for success
  */
 export default async function developAdmin(options) {
-  Logger.info({ options }, "Starting Open Commerce Admin Application Server in dev mode");
+  Logger.info("Starting Open Commerce Admin Application Server in dev mode", { options });
   const api = spawn("npm", ["run", "start:dev"]);
   api.stdout.on("data", (data) => {
     // eslint-disable-next-line no-console

--- a/commands/develop-api.js
+++ b/commands/develop-api.js
@@ -8,7 +8,7 @@ import Logger from "../utils/logger.js";
  * @returns {Boolean} true for success
  */
 export default async function developApi(options) {
-  Logger.info({ options }, "starting development on api");
+  Logger.info("starting development on api", { options });
   Logger.info("Starting Mongo docker image");
   const mongo = spawn("docker-compose", ["up", "-d"]);
   mongo.stdout.on("data", (data) => {

--- a/commands/develop-storefront.js
+++ b/commands/develop-storefront.js
@@ -8,7 +8,7 @@ import Logger from "../utils/logger.js";
  * @returns {Boolean} true for success
  */
 export default async function developStorefront(options) {
-  Logger.info({ options }, "Starting Open Commerce Admin Application Server in dev mode");
+  Logger.info("Starting Open Commerce Admin Application Server in dev mode", { options });
   const api = spawn("yarn", ["run", "start:dev"]);
   api.stdout.on("data", (data) => {
     // eslint-disable-next-line no-console

--- a/commands/index.js
+++ b/commands/index.js
@@ -2,11 +2,13 @@ import demo from "./demo.js";
 import createProject from "./create-project.js";
 import createPlugin from "./create-plugin.js";
 import develop from "./develop.js";
+import logcheck from "./logcheck.js";
 
 
 export default {
   demo,
   createProject,
   develop,
-  createPlugin
+  createPlugin,
+  logcheck
 };

--- a/commands/logcheck.js
+++ b/commands/logcheck.js
@@ -1,0 +1,19 @@
+import logger from "../utils/logger.js";
+
+/**
+ * @summary function to just check what logging looks like
+ * @returns {Boolean} true
+ */
+export default function logCheck() {
+  logger.info("Starting INFO logging");
+  logger.info("Logging with object", { this: "thing" });
+  logger.warn("Starting WARN logging");
+  logger.warn("Logging with object", { this: "thing" });
+  logger.error("Starting ERROR logging");
+  logger.error("Logging with object", { this: "thing" });
+  logger.debug("Starting DEBUG logging");
+  logger.debug("Logging with object", { this: "thing" });
+  logger.success("Starting SUCCESS logging");
+  logger.success("Logging with object", { this: "thing" });
+  return true;
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ program
   });
 
 program
+  .command("logcheck").action(() => {
+    commands.logcheck();
+  });
+
+program
   .command("create-project")
   .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin"]))
   .argument("<name>", "what to name the project")

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,45 +1,54 @@
 import chalk from "chalk";
 
+const cliName = "reaction-cli";
+
 /* eslint-disable no-console */
 
 /**
- * @summary info logger
- * @param {Object} obj = An object of any extra data
+ * @summary generic logger
+ * @param {String} color - The color to output the log message
  * @param {String} msg - String to display
+ * @param {Object} obj - An object of any extra data
  * @returns {undefined} undefined
  */
-function info(obj, msg) {
-  if (obj) {
-    const stringifiedObj = JSON.stringify(obj, 2, null);
-    console.log(chalk.blue(`cli: ${stringifiedObj}: ${msg}`));
+function log(color, msg, obj = "") {
+  if (obj && typeof obj === "object") {
+    const stringifiedObj = JSON.stringify(obj, null, 0);
+    console.log((`${chalk.blueBright(cliName)}: ${chalk[color](msg)}: ${chalk[color](stringifiedObj)})`));
   } else {
-    console.log(chalk.blue(`cli: ${msg}`));
+    console.log((`${chalk.blueBright(cliName)}: ${chalk[color](msg)}`));
   }
+}
+
+/**
+ * @summary info logger
+ * @param {String} msg - String to display
+ * @param {Object} obj = An object of any extra data
+ * @returns {undefined} undefined
+ */
+function info(msg, obj) {
+  log("blue", msg, obj);
 }
 
 const loggers = {
   info,
-  success(msg) {
-    console.log(chalk.green(`cli: ${msg}`));
+  success(msg, obj = "") {
+    log("green", msg, obj);
   },
-  warn(msg) {
-    console.log(chalk.yellow(`cli: ${msg}`));
+  warn(msg, obj = "") {
+    log("yellow", msg, obj);
   },
-  error(msg) {
-    console.log(chalk.bold.red(`cli: ${msg}`));
+  error(msg, obj = "") {
+    log("red", msg, obj);
   },
-  debug(msg) {
+  debug(msg, obj = "") {
+    let debugMessage;
     if (process.env.REACTION_CLI_DEBUG === "true") {
-      console.log(chalk.yellow("[DEBUG]:"), msg);
+      debugMessage = `[DEBUG] ${msg}`;
+    } else {
+      debugMessage = msg;
     }
-  },
-  args(args) {
-    if (process.env.REACTION_CLI_DEBUG === "true") {
-      console.log(chalk.yellow("\n[CLI Debug]\n\n"), args, "\n");
-    }
-  },
-  default(msg) {
-    console.log(`cli: ${msg}`);
+    log("cyan", debugMessage, obj);
   }
 };
 


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Changed the signature of logging everywhere (was using the Reaction Logger signature of `<optional obj>`, `<message>`) when I realized that didn't make any sense for this project so I made it (msg, obj) so I had to change that everywhere.

To test:

1. Pull and reinstall
2. `reaction logcheck` will do logging in all levels with and without an object

**Note** Depending on what order this gets merged some other stuff might break since I changed the logging signature that affects other code that's not merged.