### PR TITLE
fix: wait for mongo shutdown, add flag to turn it off

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ program
   .addArgument(new commander.Argument("[type]", "which project type to develop on")
     .choices(["api", "storefront", "admin"])
     .default("api"))
-  .option("--debug")
+  .option("--no-debug")
+  .option("--no-mongo-shutdown", "don't shut down mongo on abort")
   .action((type, options) => {
     commands.develop(type, options);
   });


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

The app wasn't shutting down mongo because it wasn't waiting before calling done. This also adds a `--no-mongo-shutdown` flag that allows you to not shut down mongo when you shutdown the app for faster stop/restarts.