### PR TITLE
fix: remove unnecessary network declaration

### DIFF
--- a/templates/api-project/docker-compose.yml
+++ b/templates/api-project/docker-compose.yml
@@ -17,4 +17,4 @@ services:
 
 volumes:
   mongo-db4:
-q
+


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

If you don't already have this network created (probably because you ran the dev platform) it would fail. There is no need that since networks are for inter-container networking which we aren't using.

To Test:
1. Ensure you have the reaction.localhost network removed.
2. Run `reaction create-project api myserver`
3. cd into myserver and run `npm install`
4. Run `reaction develop api` and ensure it starts completely