### PR TITLE
feat: make demo command consistent with other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open Commerce includes an Admin panel for managing your system plus an example s
 ### More Commands
 
 * You can run `reaction build <api|admin|storefront>` to build a dockerfile that includes your custom code while in the directory
-* You can run `reaction demo` to install and run a docker-compose file that will launch all of the projects so that you can test them out. This is for evaluation purposes, not development.
+* You can run `reaction create-project demo <my-demo>` to install and run a docker-compose file that will launch all of the projects so that you can test them out. This is for evaluation purposes, not development.
 
 
 ### Telemetry

--- a/commands/create-project-demo.js
+++ b/commands/create-project-demo.js
@@ -24,7 +24,7 @@ async function createDemoDirectory(demoPath) {
  * @returns {Boolean} true if successful
  the demo directory
  */
-export default async function demo(demoPath) {
+export default async function createProjectDemo(demoPath) {
   if (await pathExists(demoPath)) {
     Logger.error(`Cannot create directory ${demoPath}, already exists`);
     return false;

--- a/commands/create-project.js
+++ b/commands/create-project.js
@@ -3,11 +3,13 @@ import checkDependencies from "../utils/checkDependencies.js";
 import createProjectApi from "./create-project-api.js";
 import createProjectAdmin from "./create-project-admin.js";
 import createProjectStorefront from "./create-project-storefront.js";
+import createProjectDemo from "./create-project-demo.js";
 
 const methodMap = {
   api: createProjectApi,
   admin: createProjectAdmin,
-  storefront: createProjectStorefront
+  storefront: createProjectStorefront,
+  demo: createProjectDemo
 };
 
 const extraDependencyMap = {

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,7 +1,7 @@
 import telemetryCheck from "../utils/telemetryCheck.js";
 import track from "../utils/track.js";
 import checkForNewVersion from "../utils/checkForNewVersion.js";
-import demo from "./demo.js";
+import createProjectDemo from "./create-project-demo.js";
 import createProject from "./create-project.js";
 import createPlugin from "./create-plugin.js";
 import develop from "./develop.js";
@@ -12,7 +12,7 @@ export default {
   demo: (demoPath) => {
     telemetryCheck();
     checkForNewVersion();
-    demo(demoPath);
+    createProjectDemo(demoPath);
     track("demo", {}, {});
   },
   createProject: (projectType, projectName, options) => {

--- a/index.js
+++ b/index.js
@@ -13,17 +13,9 @@ const program = new commander.Command();
 program.version(pkg.version);
 
 program
-  .command("demo")
-  .description("Run Open Commerce locally in non-dev mode using docker-compose")
-  .argument("<path>", "Where to copy the demo files")
-  .action((path) => {
-    commands.demo(path);
-  });
-
-program
   .command("create-project")
   .description("Create a new Open Commerce project of one of the three types")
-  .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin"]))
+  .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin", "demo"]))
   .argument("<name>", "what to name the project")
   .option("--populate")
   .action((type, name, options) => {


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Removes the `demo` command and replaces it with `create-project demo`