### PR TITLE
fix: run mongo start command as blocking function

### DIFF
--- a/utils/runCommandInSpawn.js
+++ b/utils/runCommandInSpawn.js
@@ -1,0 +1,23 @@
+import { spawn } from "child_process";
+
+/**
+ * @summary run a command in a blocking method using a promise
+ * @param {String} command - The command to run
+ * @param {Array<String>} args - The arguments to pass to the command as an array
+ * @param {Object} options - The options to pass to the spawn as an object
+ * @returns {Promise<Boolean>} true if successful
+ */
+export default async function runCommandInSpawn(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const cmd = spawn(command, args, options);
+    cmd.stdout.on("data", (data) => {
+      // eslint-disable-next-line no-console
+      console.log(data.toString().trim()); // Echo output of command to console
+    });
+    cmd.stderr.on("data", (data) => {
+      // eslint-disable-next-line no-console
+      console.log(data.toString().trim()); // Echo error output
+    });
+    cmd.stdout.on("close", () => resolve(true));
+  });
+}


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Resolves #53 

This should fix the issue where Mongo doesn't start before API starts. Wraps a spawn in a promise that on resolves on "close" from stdout. If this work I will probably replace some of the other boilerplate spawn code with this function.

**Testing Instructions**

1. Ensure that Mongo is not running
2. In a scratch directory do `reaction create-project api myserver`
3. cd into the directory and do `npm install`
4. Do `reaction develop api`
5. Observe that the Mongo docker container is launched before it starts to launch the api

```
reaction-cli: Starting Mongo docker image
Creating network "myserver_default" with the default driver
Creating myserver_mongo_1 ... done

> myserver@1.0.0 start:dev /home/brent/Projects/merchstack/cli-test-projects/feb-17-2022/myserver
> npm run check-node-version && NODE_ENV=development NODE_OPTIONS='--experimental-modules --experimental-json-modules' nodemon ./index.js
> myserver@1.0.0 check-node-version
```