### PR TITLE
fix: check if custom-package directory exists

### DIFF
--- a/commands/create-plugin-api.js
+++ b/commands/create-plugin-api.js
@@ -79,11 +79,15 @@ async function addToPluginsJson(pluginName) {
  * @returns {Boolean} true for success
  */
 export default async function createPluginApi(pluginName, options) {
+  if (!await pathExists("custom-packages")) {
+    Logger.error("It doesn't appear that you are in an api project directory");
+    return false;
+  }
   Logger.info("Creating API plugin", { pluginName, options });
   const pluginPath = path.join("custom-packages", pluginName);
   if (await pathExists(pluginPath)) {
     Logger.error(`Cannot create directory ${pluginName}, already exists`);
-    return;
+    return false;
   }
 
   await cloneFromExample(pluginPath);
@@ -91,4 +95,5 @@ export default async function createPluginApi(pluginName, options) {
   await gitInitDirectory(pluginPath);
   await addToPluginsJson(pluginName);
   Logger.info("Plugin creation complete");
+  return true;
 }


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Resolves #40 


**Testing Instruction**
1. Run `reaction create-plugin api myplugin`. Observe that it warns you that you aren't in a project
2. Run `reaction create-project api myserver`
3. cd into the directory
4. Run `reaction create-plugin api myplugin`. Observe that it creates the plugin