### PR TITLE
Implements feature to auto detect project type

### DIFF
--- a/commands/create-project-api.js
+++ b/commands/create-project-api.js
@@ -42,6 +42,7 @@ async function updatePackageJson(packageJson, projectName) {
   packageData.scripts = newScripts;
   packageData.name = projectName;
   packageData.version = "1.0.0";
+  packageData.reactionProjectType = 'api';
   delete packageData.release;
   delete packageData.homepage;
   delete packageData.url;

--- a/commands/create-project-api.js
+++ b/commands/create-project-api.js
@@ -42,7 +42,7 @@ async function updatePackageJson(packageJson, projectName) {
   packageData.scripts = newScripts;
   packageData.name = projectName;
   packageData.version = "1.0.0";
-  packageData.reactionProjectType = 'api';
+  packageData.reactionProjectType = "api";
   delete packageData.release;
   delete packageData.homepage;
   delete packageData.url;

--- a/commands/create-project-api.js
+++ b/commands/create-project-api.js
@@ -42,7 +42,7 @@ async function updatePackageJson(packageJson, projectName) {
   packageData.scripts = newScripts;
   packageData.name = projectName;
   packageData.version = "1.0.0";
-  packageData.reactionProjectType = "api";
+  packageData.projectType = "api";
   delete packageData.release;
   delete packageData.homepage;
   delete packageData.url;

--- a/commands/develop.js
+++ b/commands/develop.js
@@ -1,7 +1,9 @@
+import fs from "fs";
 import checkDependencies from "../utils/checkDependencies.js";
 import developStorefront from "./develop-storefront.js";
 import developAdmin from "./develop-admin.js";
 import developApi from "./develop-api.js";
+import Logger from "../utils/logger.js";
 
 const functionMap = {
   api: developApi,
@@ -13,6 +15,43 @@ const extraDependencyMap = {
   storefront: ["yarn"]
 };
 
+const validProjectTypes = ['api', 'admin-meteor', 'storefront-example'];
+
+/**
+ * @summary check if reactionProjectType exists, if not return empty string
+ * @returns {String} - The project type
+ */
+ async function getProjectType() {
+  Logger.info("Getting project type");
+  const packageJson = fs.readFileSync("package.json", { encoding: "utf8", flag: "r" });
+  const packageJsonData = JSON.parse(packageJson);
+  const projectType = packageJsonData.reactionProjectType;
+
+  if (!projectType || projectType === "") {
+    Logger.error("No project type found in package.json");
+    return "";
+  }
+
+  if (!validProjectTypes.includes(projectType)) {
+    Logger.error("No valid project type found in package.json");
+    return "";
+  }
+
+  switch (projectType) {
+    case "api":
+      Logger.info("Found project type: api");
+      return "api";
+    case "admin-meteor":
+      Logger.info("Found project type: admin-meteor");
+      return "admin";
+    case "storefront-example":
+      Logger.info("Found project type: storefront-example");
+      return "storefront";
+    default:
+      Logger.error("No valid project type found in package.json");
+      return "";
+  }
+ }
 
 /**
  * @summary Run api in development mode
@@ -21,9 +60,21 @@ const extraDependencyMap = {
  * @returns {Promise<Boolean>} True for success
  */
 export default async function develop(projectType, options) {
-  const dependenciesOk = await checkDependencies(extraDependencyMap[projectType]);
+  Logger.info("Developing project", { projectType, options });
+  let projectTypeFound = "";
+  if (projectType) {
+    projectTypeFound = projectType;
+  } else {
+    projectTypeFound = await getProjectType();
+  }
+  if (!projectTypeFound || projectTypeFound === "") {
+    Logger.error("No project type found");
+    return false;
+  }
+
+  const dependenciesOk = await checkDependencies(extraDependencyMap[projectTypeFound]);
   if (dependenciesOk) {
-    return functionMap[projectType](options);
+    return functionMap[projectTypeFound](options);
   }
   return false;
 }

--- a/commands/develop.js
+++ b/commands/develop.js
@@ -25,7 +25,7 @@ async function getProjectType() {
   Logger.info("Getting project type");
   const packageJson = fs.readFileSync("package.json", { encoding: "utf8", flag: "r" });
   const packageJsonData = JSON.parse(packageJson);
-  const projectType = packageJsonData.projectType;
+  const { projectType } = packageJsonData;
 
   if (!projectType || projectType === "") {
     Logger.error("No project type found in package.json");

--- a/commands/develop.js
+++ b/commands/develop.js
@@ -18,14 +18,14 @@ const extraDependencyMap = {
 const validProjectTypes = ["api", "admin-meteor", "storefront-example"];
 
 /**
- * @summary check if reactionProjectType exists, if not return empty string
+ * @summary check if projectType exists, if not return empty string
  * @returns {String} - The project type
  */
 async function getProjectType() {
   Logger.info("Getting project type");
   const packageJson = fs.readFileSync("package.json", { encoding: "utf8", flag: "r" });
   const packageJsonData = JSON.parse(packageJson);
-  const projectType = packageJsonData.reactionProjectType;
+  const projectType = packageJsonData.projectType;
 
   if (!projectType || projectType === "") {
     Logger.error("No project type found in package.json");

--- a/commands/develop.js
+++ b/commands/develop.js
@@ -1,9 +1,9 @@
 import fs from "fs";
+import Logger from "../utils/logger.js";
 import checkDependencies from "../utils/checkDependencies.js";
 import developStorefront from "./develop-storefront.js";
 import developAdmin from "./develop-admin.js";
 import developApi from "./develop-api.js";
-import Logger from "../utils/logger.js";
 
 const functionMap = {
   api: developApi,
@@ -15,13 +15,13 @@ const extraDependencyMap = {
   storefront: ["yarn"]
 };
 
-const validProjectTypes = ['api', 'admin-meteor', 'storefront-example'];
+const validProjectTypes = ["api", "admin-meteor", "storefront-example"];
 
 /**
  * @summary check if reactionProjectType exists, if not return empty string
  * @returns {String} - The project type
  */
- async function getProjectType() {
+async function getProjectType() {
   Logger.info("Getting project type");
   const packageJson = fs.readFileSync("package.json", { encoding: "utf8", flag: "r" });
   const packageJsonData = JSON.parse(packageJson);
@@ -51,7 +51,7 @@ const validProjectTypes = ['api', 'admin-meteor', 'storefront-example'];
       Logger.error("No valid project type found in package.json");
       return "";
   }
- }
+}
 
 /**
  * @summary Run api in development mode

--- a/index.js
+++ b/index.js
@@ -37,8 +37,7 @@ program
   .command("develop")
   .description("Run a project in locally in development mode")
   .addArgument(new commander.Argument("[type]", "which project type to develop on")
-    .choices(["api", "storefront", "admin"])
-    .default("api"))
+    .choices(["api", "storefront", "admin"]))
   .option("--no-debug")
   .option("--no-mongo-shutdown", "don't shut down mongo on abort")
   .action((type, options) => {


### PR DESCRIPTION
Signed-off-by: Sujith <sujith@merchstack.com>

Resolves #25 
Impact: medium
Type: feature

## Issue
Issue as mentioned in the ticket- Develop feature to Auto-detect project type so that you can just type "reaction develop" rather than "reaction develop api"

## Solution
Added a new property to package.json which would identify the project type. 
"projectType": "api" | "admin-meteor" | "storefront-example"
While issuing 'develop' command, we check if the projectType is provided by user as args and use it if present. Else we check for the newly introduced projectType property in package.json. If not found or if invalid, we throw error and exit.

## Note
Follow-up PR required to add the projectType into package.json of the core repos
https://github.com/reactioncommerce/reaction-admin.git
https://github.com/reactioncommerce/example-storefront.git

## Breaking changes
None.

## Non-breaking change
Removed the option of using 'api' as default in index.js

## Testing
Tested both cases of executing develop command with and without projectType argument - pass
Tested case where there is no projectType entry in package.json - pass
Tested case where there is invalid projectType entry in package.json - pass
