### PR TITLE
feat: add populate option when create api project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.vscode
 node_modules
 mydir
 myadmin

--- a/commands/create-project-api.js
+++ b/commands/create-project-api.js
@@ -10,20 +10,6 @@ import Logger from "../utils/logger.js";
 const reactionRepoRoot = "https://raw.githubusercontent.com/reactioncommerce/reaction/trunk";
 
 /**
- * @summary create the git instance
- * @param {String} projectName - The name of the directory to create
- * @returns {Object} - the git instance
- */
-function getGitInstance(projectName) {
-  const gitOptions = {
-    baseDir: `${process.cwd()}/${projectName}`,
-    binary: "git",
-    maxConcurrentProcesses: 6
-  };
-  return simpleGit(gitOptions);
-}
-
-/**
  * @summary create project directory
  * @param {String} projectName - The name of the directory to create
  * @returns {Promise<Boolean>} true if success
@@ -130,6 +116,19 @@ async function getFilesFromCore(projectName, options) {
   return true;
 }
 
+/**
+ * @summary create the git instance
+ * @param {String} projectName - The name of the directory to create
+ * @returns {Object} - the git instance
+ */
+function getGit(projectName) {
+  const gitOptions = {
+    baseDir: `${process.cwd()}/${projectName}`,
+    binary: "git",
+    maxConcurrentProcesses: 6
+  };
+  return simpleGit(gitOptions);
+}
 
 /**
  * @summary git init the newly created project
@@ -137,9 +136,8 @@ async function getFilesFromCore(projectName, options) {
  * @returns {Promise<Boolean>} true if success
  */
 async function gitInitDirectory(projectName) {
-  const git = getGitInstance(projectName);
   try {
-    await git.init();
+    await getGit(projectName).init();
   } catch (error) {
     Logger.error(error);
   }
@@ -152,9 +150,8 @@ async function gitInitDirectory(projectName) {
  * @returns {Promise<boolean>} true for success
  */
 async function addSampleDataPlugin(projectName) {
-  const git = getGitInstance(projectName);
   try {
-    await git.clone("git@github.com:reactioncommerce/api-plugin-sample-data.git", "custom-packages/api-plugin-sample-data");
+    await getGit(projectName).clone("git@github.com:reactioncommerce/api-plugin-sample-data.git", "./custom-packages/api-plugin-sample-data");
 
     const pluginJsonPath = `${projectName}/plugins.json`;
     const plugins = JSON.parse(await readFile(pluginJsonPath));

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
   .description("Create a new Open Commerce project of one of several types")
   .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin", "demo"]))
   .argument("<name>", "what to name the project")
-  // .option("--populate")
+  .option("--populate", "Install the sample data plugin")
   .option("--skip-meteor-install", "Skip Meteor install when creating admin project")
   .option("--dont-start-demo", "Don't auto start the demo project after creation")
   .action((type, name, options) => {

--- a/tests/create-api-project.js
+++ b/tests/create-api-project.js
@@ -33,6 +33,8 @@ describe("The create-project-api command", () => {
   it("should print the correct output when user run with --populate option", async () => {
     const response = await execute("./index.js", ["create-project", "api", "myshop", "--populate"]);
     const responseLines = response.trim().split(EOL);
+    // eslint-disable-next-line no-console
+    console.log(response);
     expect(responseLines[1]).equal("reaction-cli: Added the sample data plugin successfully.");
     expect(responseLines[2]).equal("reaction-cli: Project creation complete. Change to your directory and run `npm install`");
 

--- a/tests/create-api-project.js
+++ b/tests/create-api-project.js
@@ -1,4 +1,5 @@
 import { EOL } from "os";
+import fs from "fs/promises";
 import { v4 as uuidv4 } from "uuid";
 import rimraf from "rimraf";
 import { expect } from "chai";
@@ -28,6 +29,19 @@ describe("The create-project-api command", () => {
     // eslint-disable-next-line jest/valid-expect
     expect(responseLines[1]).to.equal("reaction-cli: Project creation complete. Change to your directory and run `npm install`");
   }).timeout(5000);
+
+  it("should print the correct output when user run with --populate option", async () => {
+    const response = await execute("./index.js", ["create-project", "api", "myshop", "--populate"]);
+    const responseLines = response.trim().split(EOL);
+    expect(responseLines[1]).equal("reaction-cli: Added the sample data plugin successfully.");
+    expect(responseLines[2]).equal("reaction-cli: Project creation complete. Change to your directory and run `npm install`");
+
+    const pluginsData = JSON.parse(await fs.readFile("./myshop/plugins.json"));
+    expect(pluginsData.sampleData).eq("./custom-packages/api-plugin-sample-data/index.js");
+
+    const envData = await fs.readFile("./myshop/.env", { encoding: "utf-8" });
+    expect(envData).contain("LOAD_SAMPLE_DATA=true");
+  }).timeout(350000);
 });
 
 afterEach(async () => {


### PR DESCRIPTION
Signed-off-by: Brian Nguyen <vanpho02@gmail.com>

# important note: cannot be tested after release `api-plugin-sample-data`

Resolves: https://github.com/reactioncommerce/cli/issues/87

# Solution
Add @reactioncommerce/api-plugin-sample-data into package.json
Add sampleDate: "@reactioncommerce/api-plugin-sample-data" into plugins.json
Add env `LOAD_SAMPLE_DATA=true`

# Testing
`reaction create-project api test --populate`