### PR TITLE
fix: update .api.env file with STORE_URL=http://localhost:4000

### DIFF
--- a/templates/demo/.api.env
+++ b/templates/demo/.api.env
@@ -1,3 +1,4 @@
 MONGO_URL=mongodb://mongo:27017/reaction
 ROOT_URL=http://localhost:3000
 STRIPE_API_KEY=YOUR_PRIVATE_STRIPE_API_KEY
+STORE_URL=http://localhost:4000


### PR DESCRIPTION
templates/demo/.api.env file was missing store url env variable. added the correct url. tested. works as intended