### PR TITLE
fix: Update command correction. Closes #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The CLI is the quickest and easiest way to develop on Open Commerce. It allows y
 ## Prerequisites 
 ---
 Before you can use the Open Commerce CLI, ensure you have all the base requirements for your operating system: 
-- We recommend installing [nmv](https://github.com/nvm-sh/nvm) 
+- We recommend installing [nvm](https://github.com/nvm-sh/nvm) 
 - [14.18.1 ≤ Node version < 16](https://nodejs.org/ja/blog/release/v14.18.1/)
 - [Yarn](https://yarnpkg.com/cli/install)
 - [Git](https://git-scm.com/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "simple-git": "^2.48.0",
         "sinon": "^14.0.0",
         "sync-fetch": "^0.3.1",
-        "update-notifier": "^5.1.0",
+        "update-notifier": "^6.0.2",
         "uuid": "^8.3.2"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "simple-git": "^2.48.0",
         "sinon": "^14.0.0",
         "sync-fetch": "^0.3.1",
-        "update-notifier": "^6.0.2",
+        "update-notifier": "^5.1.0",
         "uuid": "^8.3.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "simple-git": "^2.48.0",
     "sinon": "^14.0.0",
     "sync-fetch": "^0.3.1",
-    "update-notifier": "^5.1.0",
+    "update-notifier": "^6.0.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/utils/checkForNewVersion.js
+++ b/utils/checkForNewVersion.js
@@ -12,5 +12,7 @@ const pkg = require("../package.json");
  */
 export default async function checkForNewVersion() {
   const notifier = updateNotifier({ pkg });
-  notifier.notify();
+  const updateCommand = "npm i -g reaction-cli";
+  const updateMessage = `Run ${updateCommand} to update.`;
+  notifier.notify({ message: updateMessage });
 }


### PR DESCRIPTION
Fixes the incorrect command display for updating to latest version of reaction-cli.
from `npm i reaction-cli` to `npm i -g reaction-cli`

Changes:
1. Added a custom `updateMessage` referring the official [documentation](https://github.com/yeoman/update-notifier#notifiernotifyoptions)  
2. Updated `update-notifier` version to latest(6.0.2) in `package.json` file
3. fixed a typo in README.md file