### PR TITLE
fix: correct the update message. Closes #62

### DIFF
--- a/utils/checkForNewVersion.js
+++ b/utils/checkForNewVersion.js
@@ -12,5 +12,7 @@ const pkg = require("../package.json");
  */
 export default async function checkForNewVersion() {
   const notifier = updateNotifier({ pkg });
-  notifier.notify();
+  const updateCommand = "npm i -g reaction-cli";
+  const updateMessage = `Run ${updateCommand} to update.`;
+  notifier.notify({ message: updateMessage });
 }


### PR DESCRIPTION
Signed-off-by: Akhil Choudhary <akhil.choudhary2000@gmail.com>

**Impact:**
Fixes the incorrect command displayed for updating to latest version of reaction-cli.
from `npm i reaction-cli` to `npm i -g reaction-cli`

**Code changes:**
Added a custom `updateMessage` referring the official [documentation](https://github.com/yeoman/update-notifier#notifiernotifyoptions)