### PR TITLE
fix: husky commit lint enabled

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "\n [Husky] Running commit-msg hook \n"
+npx --no -- commitlint --edit ${1}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
+. "$(dirname -- "$0")/_/husky.sh"
 echo "\n [Husky] Running commit-msg hook \n"
 npx --no -- commitlint --edit ${1}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "node --experimental-json-modules --no-warnings node_modules/mocha/bin/_mocha ./tests/*.* --full-trace",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -66,11 +67,6 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   },
   "prettier": {
     "arrowParens": "always"


### PR DESCRIPTION
Signed-off-by: Vikhyath A Maiya [9211vikhyath@gmail.com](9211vikhyath@gmail.com)

**Description**

As part of the PR , i have enabed the Commitlint to packages to enforce commit style for semantic release.

**Issue:**

https://github.com/reactioncommerce/cli/issues/120