### PR TITLE
Add error handling and messages to prevent running develop

### DIFF
--- a/utils/checkBeforeDevelop.js
+++ b/utils/checkBeforeDevelop.js
@@ -1,6 +1,7 @@
 import Logger from "../utils/logger.js";
 import pathExists from "./pathExists.js";
 import checkPort from "./checkPort.js";
+import getProjectType from "./getProjectType.js";
 
 /**
  * @summary check that the API server is running
@@ -17,6 +18,10 @@ async function checkForApi() {
  * @returns {Promise<boolean>} - If everything is ready for develop
  */
 export default async function checkBeforeDevelop(type = "api") {
+  if ( await getProjectType() !== type ) {
+    Logger.error(`Cannot run develop, no project of type "${type}" in current directory.`);
+    return false;
+  }
   if (!await pathExists("node_modules")) {
     if (type === "storefront") {
       Logger.error("It looks like you have not run `yarn install` in this directory");

--- a/utils/getProjectType.js
+++ b/utils/getProjectType.js
@@ -9,11 +9,25 @@ const validProjectTypes = ["api", "admin-meteor", "storefront-example"];
  */
 export default async function getProjectType() {
   Logger.info("Getting project type");
-  const packageJson = fs.readFileSync("package.json", {
-    encoding: "utf8",
-    flag: "r"
-  });
-  const packageJsonData = JSON.parse(packageJson);
+  try {
+    const packageJson = fs.readFileSync("package.json", {
+      encoding: "utf8",
+      flag: "r"
+    });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      Logger.error("Cannot read package.json in current directory");
+      return "";
+    } else {
+      throw err;
+    }
+  }
+  try {
+    const packageJsonData = JSON.parse(packageJson);
+  } catch (err) {
+    Logger.error("Error while parsing package.json");
+    return "";
+  }
   const { projectType } = packageJsonData;
 
   if (!projectType || projectType === "") {


### PR DESCRIPTION
Add error handling and messages to prevent running develop while in a directory without a project already defined

solves https://github.com/reactioncommerce/cli/issues/23