### PR TITLE
Issue70 add all option to create-project

### DIFF
--- a/commands/create-project.js
+++ b/commands/create-project.js
@@ -9,12 +9,25 @@ const methodMap = {
   api: createProjectApi,
   admin: createProjectAdmin,
   storefront: createProjectStorefront,
-  demo: createProjectDemo
+  demo: createProjectDemo,
+  all: createProjectAll
 };
 
 const extraDependencyMap = {
   storefront: ["yarn"]
 };
+
+/**
+ * @summary creates api, admin, and storefront projects at same time in separate directories.
+ * @param {String} projectName - The name of the project to create
+ * @param {Object} options - Project options
+ */
+export async function createProjectAll(projectName, options) {
+  createProjectApi(projectName + "Api", options);
+  createProjectAdmin(projectName + "Admin", options);
+  createProjectStorefront(projectName + "Storefront", options);
+  return true;
+}
 
 /**
  * @summary create one of the project types

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ program
 program
   .command("create-project")
   .description("Create a new Open Commerce project of one of several types")
-  .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin", "demo"]))
+  .addArgument(new commander.Argument("<type>", "which project type to create").choices(["api", "storefront", "admin", "all", "demo"]))
   .argument("<name>", "what to name the project")
   // .option("--populate")
   .option("--skip-meteor-install", "Skip Meteor install when creating admin project")


### PR DESCRIPTION
Adds an `all` option for create-project, sub-directories are created with the suffixes `Api`, `Admin`, and `Storefront`

Solves https://github.com/reactioncommerce/cli/issues/70