### PR TITLE
`update` no longer fail when deprecated plugins exist

### DIFF
--- a/commands/update.js
+++ b/commands/update.js
@@ -111,12 +111,18 @@ export default async function update(options) {
   const remoteDependencies = await getRemoteDependencies();
 
   const outdatedPackages = pluginPackages
-    .map(({ name, version }) => ({
-      name,
-      version,
-      remoteVersion: remoteDependencies[name],
-      outdated: compareVersions.compare(cleanVersion(remoteDependencies[name]), cleanVersion(version), ">")
-    }))
+    .map(({ name, version }) => {
+      const remoteDependency = remoteDependencies[name];
+      if (remoteDependency === undefined) {
+        Logger.warn(`Plugin ${name} used by the local project has been officially deprecated.`);
+      }
+      return {
+        name,
+        version,
+        remoteVersion: remoteDependencies[name],
+        outdated: remoteDependency && compareVersions.compare(cleanVersion(remoteDependency), cleanVersion(version), ">")
+      };
+    })
     .filter(({ outdated }) => outdated);
 
   if (outdatedPackages.length === 0) {


### PR DESCRIPTION
Resolves #156 

Before comparing the local plugin version with the remote plugin version, check if the remote plugin still exists. In not, display a warning that the local project is using a deprecated plugin.

Test steps:
1. Create a project through the cli
2. Install the `@reactioncommerce/api-plugin-payments-stripe` plugin which has been deprecated
3. Run the `reaction update` command
4. In the logs you should see a warning that the stripe plugin has been deprecated but the `update` command will succeed nonetheless.

Signed-off-by: tedraykov <tedraykov@gmail.com>